### PR TITLE
changing android version used in gradle to 23

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "in.co.ophio.secure.sample"
         minSdkVersion 18
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
@vashisthg 
- travis build was failing due to compileSdkVersion `22`
