### PR TITLE
dont-encrypt-nulls

### DIFF
--- a/library/src/androidTest/java/in/co/ophio/secure/core/ObscuredSharedPreferencesTest.java
+++ b/library/src/androidTest/java/in/co/ophio/secure/core/ObscuredSharedPreferencesTest.java
@@ -2,6 +2,7 @@ package in.co.ophio.secure.core;
 
 import android.content.SharedPreferences;
 import android.test.AndroidTestCase;
+import org.mockito.internal.util.collections.Sets;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -98,5 +99,19 @@ public class ObscuredSharedPreferencesTest extends AndroidTestCase {
 
         obscuredSharedPreferences.edit().remove(KEY_STRING);
         assertThat(obscuredSharedPreferences.contains(KEY_STRING), is(true));
+    }
+
+    public void testSetNulls() throws Exception {
+        obscuredSharedPreferences.edit().putString(KEY_STRING, "test").commit();
+        assertNotNull(obscuredSharedPreferences.getString(KEY_STRING, null));
+
+        obscuredSharedPreferences.edit().putString(KEY_STRING, null).commit();
+        assertNull(obscuredSharedPreferences.getString(KEY_STRING, null));
+
+        obscuredSharedPreferences.edit().putStringSet(KEY_STRINGSET, Sets.newSet("one", "two")).commit();
+        assertNotNull(obscuredSharedPreferences.getStringSet(KEY_STRINGSET, null));
+
+        obscuredSharedPreferences.edit().putStringSet(KEY_STRINGSET, null).commit();
+        assertNull(obscuredSharedPreferences.getStringSet(KEY_STRINGSET, null));
     }
 }

--- a/library/src/main/java/in/co/ophio/secure/core/ObscuredSharedPreferences.java
+++ b/library/src/main/java/in/co/ophio/secure/core/ObscuredSharedPreferences.java
@@ -283,13 +283,13 @@ public class ObscuredSharedPreferences implements SharedPreferences {
 
         @Override
         public Editor putString(String key, String value) {
-            delegate.putString(encryptKey(key), encrypt(value));
+            delegate.putString(encryptKey(key), value != null ? encrypt(value) : null);
             return this;
         }
 
         @Override
         public SharedPreferences.Editor putStringSet(String key, Set<String> values) {
-            delegate.putStringSet(encryptKey(key), encryptSet(values));
+            delegate.putStringSet(encryptKey(key), values != null ? encryptSet(values) : null);
             return this;
         }
 


### PR DESCRIPTION
@vashisthg when we save a null string for example, it's retrieved from prefs as an empty string ("")
